### PR TITLE
fix: handle cold-start — add /api/public/resume/ping endpoint

### DIFF
--- a/docs/designs/resume-jd-tailoring.md
+++ b/docs/designs/resume-jd-tailoring.md
@@ -30,13 +30,14 @@
 
 ### 3.1 核心思路
 
-VedaAide.NET 为 resume 站提供**唯一一个专供公开接口**：
+VedaAide.NET 为 resume 站提供两个专供公开接口：
 
 ```
-POST /api/public/resume/tailor
+GET  /api/public/resume/ping    # 轻量健康探针，用于前端检测冷启动是否完成
+POST /api/public/resume/tailor  # 流式生成定制简历（SSE）
 ```
 
-该接口：
+这两个接口：
 - `[AllowAnonymous]` — 不要求 JWT，无需登录；
 - 仅允许来自 resume 站 origin 的跨域请求（CORS 白名单）；
 - 专用严格限流（per-IP），防止 LLM 配额滥用；

--- a/src/Veda.Api/Controllers/PublicResumeTailorController.cs
+++ b/src/Veda.Api/Controllers/PublicResumeTailorController.cs
@@ -20,6 +20,14 @@ public sealed class PublicResumeTailorController(
     IPublicResumeTailoringService tailoringService,
     IOptions<VedaOptions> options) : ControllerBase
 {
+    /// <summary>
+    /// 轻量健康探针，用于前端检测 Container App 是否已从冷启动恢复。
+    /// GET /api/public/resume/ping → 200 OK { "status": "ok" }
+    /// </summary>
+    [HttpGet("ping")]
+    [ProducesResponseType(StatusCodes.Status200OK)]
+    public IActionResult Ping() => Ok(new { status = "ok" });
+
     [HttpPost("tailor")]
     [ProducesResponseType(StatusCodes.Status200OK)]
     [ProducesResponseType(StatusCodes.Status400BadRequest)]


### PR DESCRIPTION
## Problem
Azure Container App with `minReplicas: 0` cold-starts when there is no traffic. The first tailor request from the resume site would fail with a network error while the container was waking up. A `payload` JS error was also seen due to marked v17 async behaviour and high-frequency `NgZone` re-entries.

## Changes

### Backend (`VedaAide.NET`)
- `PublicResumeTailorController`: add `GET /api/public/resume/ping` — lightweight health probe (no auth, reuses existing CORS + rate-limit policy)
- `docs/designs/resume-jd-tailoring.md`: update API table to reflect the new endpoint

### Frontend (`resume` — separate repo, already merged to master)
- `TailorService`: new `ping()` method; `tailor()` loop moved to `ngZone.runOutsideAngular()` with `observer.closed` guards
- `JobTailorComponent`: ping before generating; warm-up banner with countdown if server is cold; `marked.parse()` fixed with `{ async: false }`
- `angular.json`: raise `anyComponentStyle` budget to 10 kB / 15 kB